### PR TITLE
Fix incorrect import path for dashboard types

### DIFF
--- a/services/supabase-logs-service.ts
+++ b/services/supabase-logs-service.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
-import type { Table, Server, NoteTemplate, LogEntry } from "@/components/billiards-timer-dashboard"
+import type { Table, Server, NoteTemplate, LogEntry } from "@/components/system/billiards-timer-dashboard"
 import { v4 as uuidv4 } from "uuid"
 import { getSupabaseClient, isSupabaseConfigured, checkSupabaseConnection } from "@/lib/supabase/client"
 import type { RealtimeSubscription } from "@supabase/supabase-js"

--- a/services/supabase-service.ts
+++ b/services/supabase-service.ts
@@ -11,7 +11,7 @@
  */
 
 import { createClient } from "@supabase/supabase-js"
-import type { Table, LogEntry, Server, NoteTemplate } from "@/components/billiards-timer-dashboard"
+import type { Table, LogEntry, Server, NoteTemplate } from "@/components/system/billiards-timer-dashboard"
 import supabaseAuthService from "./supabase-auth-service"
 import supabaseTablesService from "./supabase-tables-service"
 import supabaseLogsService from "./supabase-logs-service"

--- a/services/supabase-settings-service.ts
+++ b/services/supabase-settings-service.ts
@@ -1,5 +1,5 @@
 import { getSupabaseClient } from "@/lib/supabase/client"
-import type { Server, NoteTemplate } from "@/components/billiards-timer-dashboard"
+import type { Server, NoteTemplate } from "@/components/system/billiards-timer-dashboard"
 
 // Servers interface for Supabase
 interface ServersRecord {

--- a/services/supabase-tables-service.ts
+++ b/services/supabase-tables-service.ts
@@ -1,5 +1,5 @@
 import { getSupabaseClient } from "@/lib/supabase/client"
-import type { Table } from "@/components/billiards-timer-dashboard"
+import type { Table } from "@/components/system/billiards-timer-dashboard"
 
 // Tables interface for Supabase
 interface TablesRecord {


### PR DESCRIPTION
## Summary
- correct the path to `billiards-timer-dashboard` types in Supabase services

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_6842bfe8417c8329bad3c7504af0328d