### PR TITLE
Fix table start before day check

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -419,10 +419,31 @@ export function BilliardsTimerDashboard() {
   });
   
   const handleStartSessionForDialog = useCallback(
-    (tableId: number, currentGuestCount: number, currentServerId: string | null) => {
-      startTableSession(tableId, currentGuestCount, currentServerId, closeTableDialog);
+    (
+      tableId: number,
+      currentGuestCount: number,
+      currentServerId: string | null,
+    ) => {
+      if (!state.settings.dayStarted) {
+        showNotification(
+          "Please start the day before starting a session",
+          "error",
+        );
+        return;
+      }
+      startTableSession(
+        tableId,
+        currentGuestCount,
+        currentServerId,
+        closeTableDialog,
+      );
     },
-    [startTableSession, closeTableDialog] 
+    [
+      state.settings.dayStarted,
+      startTableSession,
+      closeTableDialog,
+      showNotification,
+    ],
   );
 
   const hasPermission = useCallback(


### PR DESCRIPTION
## Summary
- ensure the day is started before a table session can be launched

## Testing
- `pnpm install`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684406c122e08329ac6ca53602916e24