### PR TITLE
Use requestAnimationFrame for timer updates

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -472,12 +472,36 @@ export function BilliardsTimerDashboard() {
   }, [supabaseNoteTemplates]);
 
   useEffect(() => {
-    const timerInterval = setInterval(() => {
-      const now = new Date();
-      setCurrentTime(now);
-      window.dispatchEvent(new CustomEvent("global-time-tick", { detail: { timestamp: now.getTime() } }));
-    }, 1000);
-    return () => clearInterval(timerInterval);
+    let frameId: number;
+
+    const tick = () => {
+      if (document.visibilityState === "visible") {
+        const now = new Date();
+        setCurrentTime(now);
+        window.dispatchEvent(
+          new CustomEvent("global-time-tick", { detail: { timestamp: now.getTime() } })
+        );
+        frameId = requestAnimationFrame(tick);
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        frameId = requestAnimationFrame(tick);
+      } else {
+        cancelAnimationFrame(frameId);
+      }
+    };
+
+    if (document.visibilityState === "visible") {
+      frameId = requestAnimationFrame(tick);
+    }
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- refactor billiards timer dashboard to use `requestAnimationFrame` for time updates
- pause updates when the page isn't visible and resume when visible
- clean up animation frame on unmount

## Testing
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6845d398b808832985f3869478135ba2