### PR TITLE
Allow service worker on localhost

### DIFF
--- a/lib/pwa/register-sw.ts
+++ b/lib/pwa/register-sw.ts
@@ -1,5 +1,10 @@
 export function registerServiceWorker() {
-  if (typeof window !== "undefined" && "serviceWorker" in navigator && window.location.protocol === "https:") {
+  const isSecure =
+    typeof window !== "undefined" &&
+    (window.location.protocol === "https:" ||
+      window.location.hostname === "localhost")
+
+  if (typeof window !== "undefined" && "serviceWorker" in navigator && isSecure) {
     window.addEventListener("load", () => {
       navigator.serviceWorker.register("/sw.js").then(
         (registration) => {


### PR DESCRIPTION
## Summary
- permit service worker registration when running on http://localhost

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8ee49f08329a03011189e07b373