### PR TITLE
Fix mobile hook initialization

### DIFF
--- a/hooks/use-mobile.ts
+++ b/hooks/use-mobile.ts
@@ -3,23 +3,15 @@
 import { useState, useEffect } from "react"
 
 export function useMobile() {
-  const [isMobile, setIsMobile] = useState(false)
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth <= 768 : false
+  )
 
   useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 768) // Adjust breakpoint as needed
-    }
+    const handleResize = () => setIsMobile(window.innerWidth <= 768)
 
-    // Initial check on mount
-    handleResize()
-
-    // Listen for window resize events
     window.addEventListener("resize", handleResize)
-
-    // Clean up the event listener on unmount
-    return () => {
-      window.removeEventListener("resize", handleResize)
-    }
+    return () => window.removeEventListener("resize", handleResize)
   }, [])
 
   return isMobile


### PR DESCRIPTION
## Summary
- initialize `useMobile` with current window width

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8f07cdc8329ac5f5cc707b17fbc