### PR TITLE
Fix login handler prop in mobile dashboard

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -1285,8 +1285,7 @@ export function BilliardsTimerDashboard() {
                     onEndDay={endDay}
                     onShowSettings={() => dispatch({ type: "SET_STATE", payload: { showSettingsDialog: true } })}
                     onLogout={handleLogout}
-                    onLogin={handleAdminLogin} 
-                    isAuthenticated={isAuthenticated} 
+                    onLogin={handleLogin}
                   />
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- use `handleLogin` for login on mobile bottom navigation
- remove `isAuthenticated` prop from `<MobileBottomNav>` since it uses `useAuth`

## Testing
- `pnpm build` *(fails: Failed to collect page data)*

------
https://chatgpt.com/codex/tasks/task_e_684efbc6565c832990e8bd9f17aed312