### PR TITLE
Fix MobileBottomNav props usage

### DIFF
--- a/components/mobile/mobile-bottom-nav.tsx
+++ b/components/mobile/mobile-bottom-nav.tsx
@@ -14,8 +14,6 @@ interface MobileBottomNavProps {
   activeTab: string
   dayStarted: boolean
   isAdmin: boolean
-  onStartDay: () => void
-  onEndDay: () => void
   onShowSettings: () => void
   onLogout: () => void
   onLogin: () => void
@@ -27,8 +25,6 @@ export function MobileBottomNav({
   activeTab,
   dayStarted,
   isAdmin,
-  onStartDay,
-  onEndDay,
   onShowSettings,
   onLogout,
   onLogin,

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -1281,12 +1281,9 @@ export function BilliardsTimerDashboard() {
                     activeTab={activeTab}
                     dayStarted={settings.dayStarted}
                     isAdmin={isAdmin}
-                    onStartDay={startDay}
-                    onEndDay={endDay}
                     onShowSettings={() => dispatch({ type: "SET_STATE", payload: { showSettingsDialog: true } })}
                     onLogout={handleLogout}
-                    onLogin={handleAdminLogin} 
-                    isAuthenticated={isAuthenticated} 
+                    onLogin={handleAdminLogin}
                   />
                 </div>
               ) : (

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -1283,7 +1283,7 @@ export function BilliardsTimerDashboard() {
                     isAdmin={isAdmin}
                     onShowSettings={() => dispatch({ type: "SET_STATE", payload: { showSettingsDialog: true } })}
                     onLogout={handleLogout}
-                    onLogin={handleAdminLogin}
+                    onLogin={handleLogin}
                   />
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- remove unused props from `MobileBottomNav`
- update `billiards-timer-dashboard` to stop passing removed props

## Testing
- `npx tsc -b > /tmp/tsc.log && grep -n "MobileBottomNav" /tmp/tsc.log`

------
https://chatgpt.com/codex/tasks/task_e_684efbc834c083298e6ebfea653d32af