### PR TITLE
Improve mobile table UI and logs

### DIFF
--- a/components/mobile/mobile-table-list.tsx
+++ b/components/mobile/mobile-table-list.tsx
@@ -26,19 +26,32 @@ export function MobileTableList({ tables, servers, logs, onTableClick }: MobileT
   const filteredTables = useMemo(() => {
     let result = [...tables]
 
-    // Filter by active status if needed
     if (filterActive) {
-      result = result.filter((table) => table.isActive)
+      result = result.filter((t) => t.isActive)
     }
 
-    // Filter by assigned server if server is logged in and filter is enabled
     if (isServer && filterAssigned && currentUser) {
-      result = result.filter((table) => table.server === currentUser.id)
+      result = result.filter((t) => t.server === currentUser.id)
     }
 
-    // Sort tables numerically by ID
-    return result.sort((a, b) => a.id - b.id)
-  }, [tables, filterActive, filterAssigned, isServer, currentUser])
+    result.sort((a, b) => {
+      if (a.isActive !== b.isActive) return a.isActive ? -1 : 1
+
+      const serverNameA = servers.find((s) => s.id === a.server)?.name || ""
+      const serverNameB = servers.find((s) => s.id === b.server)?.name || ""
+      if (serverNameA !== serverNameB) return serverNameA.localeCompare(serverNameB)
+
+      if (a.hasNotes !== b.hasNotes) return a.hasNotes ? -1 : 1
+
+      const guestA = a.guestCount >= 4
+      const guestB = b.guestCount >= 4
+      if (guestA !== guestB) return guestA ? -1 : 1
+
+      return a.id - b.id
+    })
+
+    return result
+  }, [tables, filterActive, filterAssigned, isServer, currentUser, servers])
 
   // Handle filter toggles with haptic feedback
   const handleFilterActiveToggle = useCallback(() => {

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -293,6 +293,7 @@ export function BilliardsTimerDashboard() {
   const [currentTime, setCurrentTime] = useState(new Date());
   const headerRef = useRef<HTMLDivElement>(null);
   const notificationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const lastNotificationRef = useRef<{ message: string; time: number } | null>(null);
 
   // Update hideSystemElements based on isMobile, only after component has mounted
   useEffect(() => {
@@ -371,6 +372,13 @@ export function BilliardsTimerDashboard() {
 
   const showNotification = useCallback(
     (message: string, type: "success" | "error" | "info" = "info") => {
+      if (
+        lastNotificationRef.current &&
+        lastNotificationRef.current.message === message &&
+        Date.now() - lastNotificationRef.current.time < 1000
+      ) {
+        return;
+      }
       if (notificationTimeoutRef.current) {
         clearTimeout(notificationTimeoutRef.current);
       }
@@ -379,6 +387,7 @@ export function BilliardsTimerDashboard() {
         dispatch({ type: "CLEAR_NOTIFICATION" });
         notificationTimeoutRef.current = null;
       }, 3000);
+      lastNotificationRef.current = { message, time: Date.now() };
 
       if (state.settings.soundEnabled && type !== "info") { // Use state.settings
         try {

--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -12,8 +12,6 @@ import {
   FileTextIcon,
   BrainIcon,
   UnplugIcon, 
-  Search, // Import Search icon
-  X // Import X icon
 } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
@@ -24,8 +22,7 @@ import { TooltipProvider } from "@/components/ui/tooltip"
 import { NumberPad } from "@/components/auth/number-pad"
 import { MenuRecommendations } from "@/components/system/menu-recommendations"
 import { useMobile } from "@/hooks/use-mobile"
-import { Input } from "@/components/ui/input" // Import Input
-import { ScrollArea } from "@/components/ui/scroll-area" // Import ScrollArea
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 
 interface TableDialogProps {
   table: Table
@@ -110,7 +107,14 @@ export function TableDialog({
   const [editingServer, setEditingServer] = useState(!table.server);
   const [mobileTabView, setMobileTabView] = useState<"logs" | "menu" | "ai" | "manage" | "notes">("logs");
   const [logActionFilter, setLogActionFilter] = useState<string | null>(null);
-  const [serverSearchTerm, setServerSearchTerm] = useState<string>(""); // New state for server search
+
+  const formatLogDetails = useCallback(
+    (details?: string) => {
+      if (!details) return '';
+      return details.replace(/Server:\s*(\w+)/, (_, id) => `Server: ${getServerName(id)}`);
+    },
+    [getServerName],
+  );
 
   const currentGuestCountRef = useRef(table.guestCount); 
   const currentServerRef = useRef(table.server);
@@ -125,9 +129,8 @@ export function TableDialog({
   const availableServers = useMemo(() => {
     return servers
       .filter((server) => server.enabled !== false)
-      .filter((server, index, self) => index === self.findIndex((s) => s.id === server.id))
-      .filter(server => server.name.toLowerCase().includes(serverSearchTerm.toLowerCase())); // Filter by search term
-  }, [servers, serverSearchTerm]);
+      .filter((server, index, self) => index === self.findIndex((s) => s.id === server.id));
+  }, [servers]);
 
   const canManageTable = useMemo(
     () =>
@@ -710,7 +713,9 @@ export function TableDialog({
                     {logs.filter((log) => log.tableId === table.id && table.startTime && log.timestamp >= table.startTime && (logActionFilter === null || log.action === logActionFilter)).sort((a, b) => b.timestamp - a.timestamp).map((log) => (
                         <div key={log.id} className="p-2 border border-[#00FFFF]/30 rounded-md bg-[#000033] mb-2" role="listitem">
                           <div className="flex justify-between text-xs text-gray-400"><span className="bg-purple-900/30 px-1 py-0.5 rounded text-purple-300">{log.action}</span><span>{new Date(log.timestamp).toLocaleTimeString([], {hour: "2-digit", minute: "2-digit"})}</span></div>
-                          {log.details && <div className="mt-1 text-sm text-[#00FFFF]">{log.details}</div>}
+                          {log.details && (
+                            <div className="mt-1 text-sm text-[#00FFFF]">{formatLogDetails(log.details)}</div>
+                          )}
                         </div>
                     ))}
                     {logs.filter((log) => log.tableId === table.id && table.startTime && log.timestamp >= table.startTime && (logActionFilter === null || log.action === logActionFilter)).length === 0 && (<div className="text-center text-gray-400 py-4"><div className="mb-2 opacity-50"><FileTextIcon className="h-8 w-8 mx-auto mb-1" /></div>{logActionFilter ? `No "${logActionFilter}" logs available` : "No session logs available"}</div>)}
@@ -750,50 +755,21 @@ export function TableDialog({
                         </div>
                       ) : (
                         <div>
-                          <div className="relative mb-2">
-                            <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                            <Input
-                              placeholder="Search server..."
-                              value={serverSearchTerm}
-                              onChange={(e) => setServerSearchTerm(e.target.value)}
-                              className="bg-[#000033] border-[#00FFFF] text-white h-8 pl-8 text-xs"
-                              disabled={viewOnlyMode}
-                            />
-                            {serverSearchTerm && (
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6 text-gray-400 hover:text-white"
-                                onClick={() => setServerSearchTerm("")}
-                              >
-                                <X className="h-3 w-3" />
-                              </Button>
-                            )}
-                          </div>
-                          <ScrollArea className="h-32 rounded-md border border-[#00FFFF]/30 p-2">
-                            <div className="grid grid-cols-3 gap-2">
-                              {availableServers.length > 0 ? (
-                                availableServers.map((server) => (
-                                  <Button
-                                    key={server.id}
-                                    variant={currentServerRef.current === server.id ? "default" : "outline"}
-                                    className={
-                                      currentServerRef.current === server.id
-                                        ? "w-full justify-center bg-[#00FF00] hover:bg-[#00CC00] text-black text-xs h-7 px-1 touch-manipulation font-bold active:scale-95"
-                                        : "w-full justify-center border-2 border-[#00FF00] bg-[#000033] hover:bg-[#000066] text-white text-xs h-7 px-1 touch-manipulation active:scale-95"
-                                    }
-                                    onClick={() => handleServerSelection(server.id)}
-                                    disabled={viewOnlyMode}
-                                    aria-label={`Select server ${server.name}`}
-                                  >
-                                    <span className="truncate">{server.name}</span>
-                                  </Button>
-                                ))
-                              ) : (
-                                <div className="col-span-3 text-center text-gray-400 text-xs py-4">No servers found</div>
-                              )}
-                            </div>
-                          </ScrollArea>
+                          <Select
+                            value={currentServerRef.current || undefined}
+                            onValueChange={(value) => handleServerSelection(value)}
+                          >
+                            <SelectTrigger className="w-full bg-[#000033] border-[#00FFFF] text-white h-9">
+                              <SelectValue placeholder="Select server" />
+                            </SelectTrigger>
+                            <SelectContent className="bg-[#000033] border-[#00FFFF] text-white max-h-[200px]">
+                              {availableServers.map((server) => (
+                                <SelectItem key={server.id} value={server.id}>
+                                  {server.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                         </div>
                       )}
                     </div>
@@ -870,53 +846,21 @@ export function TableDialog({
                     ) 
                     : (
                       <div>
-                        {/* Server Search Input */}
-                        <div className="relative mb-2">
-                          <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                          <Input
-                            placeholder="Search server..."
-                            value={serverSearchTerm}
-                            onChange={(e) => setServerSearchTerm(e.target.value)}
-                            className="bg-[#000033] border-[#00FFFF] text-white h-8 pl-8 text-xs"
-                            disabled={viewOnlyMode}
-                          />
-                          {serverSearchTerm && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6 text-gray-400 hover:text-white"
-                              onClick={() => setServerSearchTerm("")}
-                            >
-                              <X className="h-3 w-3" />
-                            </Button>
-                          )}
-                        </div>
-
-                        {/* Scrollable Server List */}
-                        <ScrollArea className="h-32 rounded-md border border-[#00FFFF]/30 p-2">
-                          <div className="grid grid-cols-3 gap-2"> {/* Adjusted to 3 columns for better fit */}
-                            {availableServers.length > 0 ? (
-                              availableServers.map((server) => (
-                                <Button 
-                                  key={server.id} 
-                                  variant={currentServerRef.current === server.id ? "default" : "outline"} 
-                                  className={
-                                    currentServerRef.current === server.id 
-                                      ? "w-full justify-center bg-[#00FF00] hover:bg-[#00CC00] text-black text-xs h-7 px-1 touch-manipulation font-bold active:scale-95" 
-                                      : "w-full justify-center border-2 border-[#00FF00] bg-[#000033] hover:bg-[#000066] text-white text-xs h-7 px-1 touch-manipulation active:scale-95"
-                                  } 
-                                  onClick={() => handleServerSelection(server.id)} 
-                                  disabled={viewOnlyMode} 
-                                  aria-label={`Select server ${server.name}`}
-                                >
-                                  <span className="truncate">{server.name}</span>
-                                </Button>
-                              ))
-                            ) : (
-                              <div className="col-span-3 text-center text-gray-400 text-xs py-4">No servers found</div>
-                            )}
-                          </div>
-                        </ScrollArea>
+                        <Select
+                          value={currentServerRef.current || undefined}
+                          onValueChange={(value) => handleServerSelection(value)}
+                        >
+                          <SelectTrigger className="w-full bg-[#000033] border-[#00FFFF] text-white h-9">
+                            <SelectValue placeholder="Select server" />
+                          </SelectTrigger>
+                          <SelectContent className="bg-[#000033] border-[#00FFFF] text-white max-h-[200px]">
+                            {availableServers.map((server) => (
+                              <SelectItem key={server.id} value={server.id}>
+                                {server.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                     )}
                   </div>
@@ -1016,7 +960,9 @@ export function TableDialog({
                           <span className="bg-purple-900/30 px-1 py-0.5 rounded text-purple-300">{log.action}</span>
                           <span>{new Date(log.timestamp).toLocaleTimeString([], {hour: "2-digit", minute: "2-digit"})}</span>
                         </div>
-                        {log.details && <div className="mt-1 text-sm text-[#00FFFF]">{log.details}</div>}
+                        {log.details && (
+                          <div className="mt-1 text-sm text-[#00FFFF]">{formatLogDetails(log.details)}</div>
+                        )}
                       </div>
                     ))}
                   {logs.filter((log) => log.tableId === table.id && table.startTime && log.timestamp >= table.startTime && (logActionFilter === null || log.action === logActionFilter)).length === 0 && (


### PR DESCRIPTION
## Summary
- add dropdown select for server assignment in table dialog
- display server names in log details
- avoid duplicate system notifications
- sort mobile table list using server, notes, and guest count

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f1530b234832998bd8621863bac7e