### PR TITLE
Fix regex for server UUIDs

### DIFF
--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -116,7 +116,7 @@ export function TableDialog({
   const formatLogDetails = useCallback(
     (details?: string) => {
       if (!details) return '';
-      return details.replace(/Server:\s*(\w+)/, (_, id) => `Server: ${getServerName(id)}`);
+      return details.replace(/Server:\s*([\w-]+)/, (_, id) => `Server: ${getServerName(id)}`);
     },
     [getServerName],
   );


### PR DESCRIPTION
## Summary
- show server names in logs by parsing UUIDs in `Server:` details

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684f225aaa648329a517fa83ec95cf9e