### PR TITLE
Throttle duplicate offline banners

### DIFF
--- a/components/mobile/offline-detector.tsx
+++ b/components/mobile/offline-detector.tsx
@@ -10,6 +10,7 @@ export function OfflineDetector() {
   const [lastStatus, setLastStatus] = useState<boolean | null>(null) // Track last status to prevent duplicate notifications
   const { isAuthenticated, isAdmin, currentUser } = useAuth()
   const statusChangeTimeout = useRef<NodeJS.Timeout | null>(null)
+  const lastChangeRef = useRef(0)
   const MIN_STATUS_CHANGE_INTERVAL = 10000 // 10 seconds minimum between status changes
 
   useEffect(() => {
@@ -31,15 +32,21 @@ export function OfflineDetector() {
       statusChangeTimeout.current = setTimeout(() => {
         setIsOnline(true)
 
-        // Only show banner if status changed
-        if (lastStatus === false) {
+        // Only show banner if status changed and not throttled
+        if (
+          lastStatus === false &&
+          Date.now() - lastChangeRef.current > MIN_STATUS_CHANGE_INTERVAL
+        ) {
           setShowBanner(true)
           setLastStatus(true)
+          lastChangeRef.current = Date.now()
 
           // Auto-hide after 5 seconds
           setTimeout(() => {
             setShowBanner(false)
           }, 5000)
+        } else {
+          setLastStatus(true)
         }
       }, 2000) // 2 second delay to ensure network is stable
     }
@@ -54,9 +61,15 @@ export function OfflineDetector() {
       statusChangeTimeout.current = setTimeout(() => {
         setIsOnline(false)
 
-        // Only show banner if status changed
-        if (lastStatus !== false) {
+        // Only show banner if status changed and not throttled
+        if (
+          lastStatus !== false &&
+          Date.now() - lastChangeRef.current > MIN_STATUS_CHANGE_INTERVAL
+        ) {
           setShowBanner(true)
+          setLastStatus(false)
+          lastChangeRef.current = Date.now()
+        } else {
           setLastStatus(false)
         }
       }, 1000) // 1 second delay
@@ -71,15 +84,21 @@ export function OfflineDetector() {
 
       setIsOnline(true)
 
-      // Only show banner if status changed
-      if (lastStatus === false) {
+      // Only show banner if status changed and not throttled
+      if (
+        lastStatus === false &&
+        Date.now() - lastChangeRef.current > MIN_STATUS_CHANGE_INTERVAL
+      ) {
         setShowBanner(true)
         setLastStatus(true)
+        lastChangeRef.current = Date.now()
 
         // Auto-hide after 5 seconds
         setTimeout(() => {
           setShowBanner(false)
         }, 5000)
+      } else {
+        setLastStatus(true)
       }
     }
 
@@ -88,9 +107,15 @@ export function OfflineDetector() {
       if (!navigator.onLine) {
         setIsOnline(false)
 
-        // Only show banner if status changed
-        if (lastStatus !== false) {
+        // Only show banner if status changed and not throttled
+        if (
+          lastStatus !== false &&
+          Date.now() - lastChangeRef.current > MIN_STATUS_CHANGE_INTERVAL
+        ) {
           setShowBanner(true)
+          setLastStatus(false)
+          lastChangeRef.current = Date.now()
+        } else {
           setLastStatus(false)
         }
       }

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -22,7 +22,6 @@ import { BigBangAnimation } from "@/components/animations/big-bang-animation";
 import { ExplosionAnimation } from "@/components/animations/explosion-animation";
 import { EnhancedMobileTableList } from "@/components/mobile/enhanced-mobile-table-list";
 import { MobileBottomNav } from "@/components/mobile/mobile-bottom-nav";
-import { OfflineDetector } from "@/components/mobile/offline-detector"; // Corrected import path
 import { OrientationAwareContainer } from "@/components/mobile/orientation-aware-container";
 import { useMobile } from "@/hooks/use-mobile";
 import { IOSTouchFix } from "@/components/ios-touch-fix";
@@ -1207,7 +1206,6 @@ export function BilliardsTimerDashboard() {
         style={{ height: "100vh", display: "flex", flexDirection: "column" }}
       >
         <IOSTouchFix />
-        <OfflineDetector />
         {notification && (
           <div
             role="alert"


### PR DESCRIPTION
## Summary
- remove redundant `OfflineDetector` from the timer dashboard
- throttle connection banner updates in `OfflineDetector`

## Testing
- `npm run lint`
- `npm run build` *(fails: VAPID keys or subject are missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f26ad53848329888656545f3d91af