### PR TITLE
Improve iPad layout and mobile interactions

### DIFF
--- a/app/ipad.css
+++ b/app/ipad.css
@@ -52,9 +52,10 @@
   }
 
   /* Landscape mode optimizations */
-  @media (orientation: landscape) {
+  @media screen and (orientation: landscape) and (min-device-width: 768px) and (max-device-width: 1024px) {
     .table-grid {
-      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      /* Match desktop layout with six fixed columns */
+      grid-template-columns: repeat(6, minmax(0, 1fr));
     }
 
     /* Adjust header for landscape */

--- a/components/mobile/swipeable-table-card.tsx
+++ b/components/mobile/swipeable-table-card.tsx
@@ -3,7 +3,7 @@
 import type React from "react";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { TableCard } from "@/components/tables/table-card"; // Adjusted path if necessary
-import { Clock, X } from "lucide-react";
+import { Clock, X, ArrowLeft, ArrowRight } from "lucide-react";
 import type { Table, Server, LogEntry } from "@/components/system/billiards-timer-dashboard";
 import { hapticFeedback } from "@/utils/haptic-feedback";
 
@@ -57,6 +57,7 @@ export function SwipeableTableCard({
     if (table.isActive && (canEndSession || canAddTime) && showAnimations) {
       swipeHintTimeoutRef.current = setTimeout(() => {
         setShowSwipeHint(true);
+        hapticFeedback.light();
         setTimeout(() => setShowSwipeHint(false), 2000);
       }, 500);
     }
@@ -86,6 +87,7 @@ export function SwipeableTableCard({
       scrollY: window.scrollY, // Store initial window scrollY
     };
     gestureType.current = null; // Reset gesture type for new touch
+    hapticFeedback.selection();
     if (cardRef.current) {
       cardRef.current.style.transition = 'none'; // Remove transition during active swipe for direct manipulation
     }
@@ -237,8 +239,10 @@ export function SwipeableTableCard({
       {/* Swipe Hint */}
       {showSwipeHint && table.isActive && showAnimations && (
          <div className="absolute inset-0 z-30 pointer-events-none flex items-center justify-center">
-          <div className="bg-black/70 text-white px-3 py-1.5 rounded-full text-xs animate-pulse">
-            {canAddTime && canEndSession ? "Swipe card for actions" : canAddTime ? "Swipe right to add time" : canEndSession ? "Swipe left to end" : ""}
+          <div className="bg-black/70 text-white px-3 py-1.5 rounded-full text-xs flex items-center gap-2 animate-pulse">
+            <ArrowLeft className="w-3 h-3" />
+            {canAddTime && canEndSession ? "Swipe" : canAddTime ? "Swipe right" : "Swipe left"}
+            <ArrowRight className="w-3 h-3" />
           </div>
         </div>
       )}

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -294,6 +294,11 @@ export function BilliardsTimerDashboard() {
   const notificationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastNotificationRef = useRef<{ message: string; time: number } | null>(null);
 
+  // Memoized selectors for frequently used state slices
+  const memoizedTables = useMemo(() => tables, [tables]);
+  const memoizedServers = useMemo(() => servers, [servers]);
+  const memoizedLogs = useMemo(() => logs, [logs]);
+
   // Update hideSystemElements based on isMobile, only after component has mounted
   useEffect(() => {
     if (hasMounted && isMobile !== undefined) {
@@ -1295,9 +1300,9 @@ export function BilliardsTimerDashboard() {
                 </div>
               ) : (
                 <TableGrid
-                  tables={tables} // Use tables from state
-                  servers={servers} // Use servers from state
-                  logs={logs}     // Use logs from state
+                  tables={memoizedTables}
+                  servers={memoizedServers}
+                  logs={memoizedLogs}
                   onTableClick={openTableDialog}
                   // showAnimations={settings.showTableCardAnimations} // Already passed to EnhancedMobileTableList
                 />
@@ -1309,10 +1314,10 @@ export function BilliardsTimerDashboard() {
         {selectedTable && (
           <TableDialog
             table={selectedTable}
-            servers={servers} // Use servers from state
-            allTables={tables} // Use tables from state
-            noteTemplates={stateNoteTemplates} // Use noteTemplates from state
-            logs={logs} // Use logs from state
+            servers={memoizedServers}
+            allTables={memoizedTables}
+            noteTemplates={stateNoteTemplates}
+            logs={memoizedLogs}
             onClose={closeTableDialog}
             onStartSession={handleStartSessionForDialog} 
             onEndSession={confirmEndSession}

--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -630,14 +630,14 @@ export function TableDialog({
       !localTable.isActive && hasPermission("canStartSession") ? (
         <Button
           size="sm" onClick={handleStartSessionClick}
-          className="h-14 w-14 p-0 rounded-full bg-[#00FF33] hover:bg-[#00CC00] text-black transition-transform duration-200 hover:scale-110 active:scale-95"
+          className="h-16 w-16 p-1 rounded-full bg-[#00FF33] hover:bg-[#00CC00] text-black transition-transform duration-200 hover:scale-110 active:scale-95"
           disabled={viewOnlyMode || !hasPermission("canStartSession")} aria-label="Start session"
         ><PlayIcon className="h-8 w-8" /></Button>
       ) : (
         localTable.isActive && (
           <Button
             size="sm" onClick={handleEndSession}
-            className="h-14 w-14 p-0 rounded-full bg-[#FF3300] hover:bg-[#CC0000] text-white transition-transform duration-200 hover:scale-110 active:scale-95"
+            className="h-16 w-16 p-1 rounded-full bg-[#FF3300] hover:bg-[#CC0000] text-white transition-transform duration-200 hover:scale-110 active:scale-95"
             disabled={viewOnlyMode || !hasPermission("canEndSession")} aria-label="End session"
           ><span className="text-lg font-bold">End</span></Button>
         )
@@ -746,10 +746,10 @@ export function TableDialog({
                     </div>
                     <div className="mt-4">
                       <div className="flex items-center justify-center mb-2"><UsersIcon className="mr-1 h-4 w-4 text-[#FF00FF]" /><h3 className="text-sm font-medium text-[#FF00FF]">Players</h3></div>
-                      <div className="flex items-center justify-center gap-5">
-                        <Button variant="outline" size="icon" className="h-12 w-12 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleDecrementGuests} disabled={viewOnlyMode} aria-label="Decrease guest count"><MinusIcon className="h-6 w-6" /></Button>
+                      <div className="flex items-center justify-center gap-6">
+                        <Button variant="outline" size="icon" className="h-14 w-14 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleDecrementGuests} disabled={viewOnlyMode} aria-label="Decrease guest count"><MinusIcon className="h-6 w-6" /></Button>
                         <div className="text-3xl font-bold w-20 h-14 text-center text-[#FF00FF] cursor-pointer rounded-md flex items-center justify-center transition-all duration-200 relative bg-[#110022] active:scale-95" onClick={handleGuestCountClick} style={{boxShadow: "0 0 10px rgba(255, 0, 255, 0.5)", border: "2px solid rgba(255, 0, 255, 0.7)"}} role="button" aria-label="Edit guest count">{guestCount}<span className="absolute bottom-1 right-1 text-[8px] text-[#FF00FF] opacity-70">tap</span></div>
-                        <Button variant="outline" size="icon" className="h-12 w-12 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleIncrementGuests} disabled={viewOnlyMode} aria-label="Increase guest count"><PlusIcon className="h-6 w-6" /></Button>
+                        <Button variant="outline" size="icon" className="h-14 w-14 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleIncrementGuests} disabled={viewOnlyMode} aria-label="Increase guest count"><PlusIcon className="h-6 w-6" /></Button>
                       </div>
                     </div>
                     <div className="mt-4">
@@ -836,10 +836,10 @@ export function TableDialog({
                   <div className="flex items-center justify-between gap-4 mt-2"><div className="flex-1 flex justify-center"><TimerDisplay /></div><ActionButton /></div>
                   <div className="mt-4">
                     <div className="flex items-center justify-center mb-2"><UsersIcon className="mr-1 h-4 w-4 text-[#FF00FF]" /><h3 className="text-sm font-medium text-[#FF00FF]">Players</h3></div>
-                    <div className="flex items-center justify-center gap-5">
-                      <Button variant="outline" size="icon" className="h-12 w-12 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleDecrementGuests} disabled={viewOnlyMode} aria-label="Decrease guest count"><MinusIcon className="h-6 w-6" /></Button>
+                    <div className="flex items-center justify-center gap-6">
+                      <Button variant="outline" size="icon" className="h-14 w-14 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleDecrementGuests} disabled={viewOnlyMode} aria-label="Decrease guest count"><MinusIcon className="h-6 w-6" /></Button>
                       <div className="text-3xl font-bold w-20 h-14 text-center text-[#FF00FF] cursor-pointer rounded-md flex items-center justify-center transition-all duration-200 relative bg-[#110022] active:scale-95" onClick={handleGuestCountClick} style={{boxShadow: "0 0 10px rgba(255, 0, 255, 0.5)", border: "2px solid rgba(255, 0, 255, 0.7)",}} role="button" aria-label="Edit guest count">{guestCount}<span className="absolute bottom-1 right-1 text-[8px] text-[#FF00FF] opacity-70">tap</span></div>
-                      <Button variant="outline" size="icon" className="h-12 w-12 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleIncrementGuests} disabled={viewOnlyMode} aria-label="Increase guest count"><PlusIcon className="h-6 w-6" /></Button>
+                      <Button variant="outline" size="icon" className="h-14 w-14 border-2 border-[#FF00FF] bg-[#000033] hover:bg-[#000066] text-[#FF00FF] transition-all duration-200 active:scale-95 shadow-md" onClick={handleIncrementGuests} disabled={viewOnlyMode} aria-label="Increase guest count"><PlusIcon className="h-6 w-6" /></Button>
                     </div>
                   </div>
                   <div className="mt-4">

--- a/hooks/use-table-timer.ts
+++ b/hooks/use-table-timer.ts
@@ -32,6 +32,7 @@ export function useTableTimer(table: HookTableInput) {
   // Use refs to avoid dependencies in the tick function
   const tableRef = useRef(table)
   const lastTickTimeRef = useRef<number>(Date.now())
+  const UPDATE_INTERVAL_MS = 1000
   // Used to keep track of the animation frame loop when a table is active
   const animationFrameIdRef = useRef<number | null>(null)
 
@@ -74,6 +75,9 @@ export function useTableTimer(table: HookTableInput) {
 
   // Tick function that doesn't depend on state values
   const tick = useCallback((currentTime: number) => {
+    if (currentTime - lastTickTimeRef.current < UPDATE_INTERVAL_MS) return
+    lastTickTimeRef.current = currentTime
+
     const currentTable = tableRef.current
 
     if (currentTable.isActive && currentTable.startTime) {


### PR DESCRIPTION
## Summary
- tweak iPad landscape grid so it matches desktop
- show swipe arrows on table cards and trigger haptic feedback
- throttle table timer updates to once per second
- enlarge buttons in table dialog for easier taps
- memoize table data in the dashboard to avoid extra renders

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687761c1a988832992f21c4e41d2f093