### PR TITLE
Optimize mobile performance

### DIFF
--- a/components/mobile/enhanced-mobile-table-list.tsx
+++ b/components/mobile/enhanced-mobile-table-list.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type React from "react";
-import { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef, useMemo, memo } from "react";
 import { SwipeableTableCard } from "@/components/mobile/swipeable-table-card"; // Adjusted path if necessary
+const MemoizedSwipeableTableCard = memo(SwipeableTableCard);
 import type { Table, Server, LogEntry } from "@/components/system/billiards-timer-dashboard";
 import { useTableStore } from "@/utils/table-state-manager";
 import { hapticFeedback } from "@/utils/haptic-feedback";
@@ -185,9 +185,13 @@ export function EnhancedMobileTableList({
     }
   }, [triggerRefresh, isRefreshing, refreshThreshold]);
 
-  const filteredAndSortedTables = [...localTables]
-    .filter((table) => !table.name.toLowerCase().includes("system"))
-    .sort((a, b) => a.id - b.id);
+  const filteredAndSortedTables = useMemo(
+    () =>
+      [...localTables]
+        .filter((table) => !table.name.toLowerCase().includes("system"))
+        .sort((a, b) => a.id - b.id),
+    [localTables],
+  );
 
   return (
     <div
@@ -228,7 +232,7 @@ export function EnhancedMobileTableList({
       <div className="space-y-4 p-4 mobile-table-card-list">
         {filteredAndSortedTables.length > 0 ? (
           filteredAndSortedTables.map((table) => (
-            <SwipeableTableCard
+            <MemoizedSwipeableTableCard
               key={table.id}
               table={table}
               servers={servers}

--- a/components/mobile/swipeable-table-card.tsx
+++ b/components/mobile/swipeable-table-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type React from "react";
-import { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { throttle } from "lodash";
 import { TableCard } from "@/components/tables/table-card"; // Adjusted path if necessary
 import { Clock, X, ArrowLeft, ArrowRight } from "lucide-react";
 import type { Table, Server, LogEntry } from "@/components/system/billiards-timer-dashboard";
@@ -93,7 +93,7 @@ export function SwipeableTableCard({
     }
   }, []);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+  const handleTouchMoveInternal = useCallback((e: React.TouchEvent) => {
     if (!touchStartDetails.current || e.touches.length > 1) return;
 
     const currentX = e.touches[0].clientX;
@@ -141,6 +141,17 @@ export function SwipeableTableCard({
       return;
     }
   }, [table.isActive, canEndSession, canAddTime, showLeftAction, showRightAction]);
+
+  const handleTouchMove = useMemo(
+    () => throttle(handleTouchMoveInternal, 16, { trailing: false }),
+    [handleTouchMoveInternal],
+  );
+
+  useEffect(() => {
+    return () => {
+      handleTouchMove.cancel();
+    };
+  }, [handleTouchMove]);
 
   const handleTouchEnd = useCallback((e: React.TouchEvent) => {
     const startDetails = touchStartDetails.current;
@@ -268,4 +279,4 @@ export function SwipeableTableCard({
   );
 }
 
-export default SwipeableTableCard;
+export default React.memo(SwipeableTableCard);

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -18,7 +18,8 @@ import { ConfirmDialog } from "@/components/dialogs/confirm-dialog";
 import { TouchLogin } from "@/components/auth/touch-login";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useTableStore } from "@/utils/table-state-manager";
-import { BigBangAnimation } from "@/components/animations/big-bang-animation";
+import dynamic from "next/dynamic";
+const BigBangAnimation = dynamic(() => import("@/components/animations/big-bang-animation"), { ssr: false });
 import { ExplosionAnimation } from "@/components/animations/explosion-animation";
 import { EnhancedMobileTableList } from "@/components/mobile/enhanced-mobile-table-list";
 import { MobileBottomNav } from "@/components/mobile/mobile-bottom-nav";
@@ -247,6 +248,15 @@ export function BilliardsTimerDashboard() {
   useEffect(() => {
     setHasMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (!hasMounted) return;
+    const ua = navigator.userAgent;
+    const isOldIpad = /iPad/.test(ua) && /OS 1[3-4]_/.test(ua);
+    if (isOldIpad) {
+      dispatch({ type: "UPDATE_SETTINGS", payload: { showTableCardAnimations: false } });
+    }
+  }, [hasMounted]);
 
   const {
     tables, // This will be from dashboardReducer state


### PR DESCRIPTION
## Summary
- throttle heavy touch handlers
- memoize table cards and filter calculations
- lazy load the BigBangAnimation
- disable table card animations on older iPads

## Testing
- `npm run lint`
- `npm run build` *(fails: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_68777c87896883299b962e32cf502b0a