### PR TITLE
Improve iPad UI

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -252,7 +252,8 @@ export function BilliardsTimerDashboard() {
   useEffect(() => {
     if (!hasMounted) return;
     const ua = navigator.userAgent;
-    const isOldIpad = /iPad/.test(ua) && /OS 1[3-4]_/.test(ua);
+    // Broaden older iPad detection to include up to iPadOS 15
+    const isOldIpad = /iPad/.test(ua) && /OS 1[3-5]_/.test(ua);
     if (isOldIpad) {
       dispatch({ type: "UPDATE_SETTINGS", payload: { showTableCardAnimations: false } });
     }

--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -658,7 +658,7 @@ export function TableDialog({
     <TooltipProvider>
       <Dialog open onOpenChange={ (openState) => { if (!openState) handleDialogClose(); } }>
         <DialogContent
-          className="max-w-[500px] bg-[#000018] text-white border-[#00FFFF] animate-in fade-in-50 duration-300 space-theme font-mono cursor-galaga overflow-y-auto p-0"
+          className="table-dialog-content max-w-[500px] sm:max-w-[550px] bg-[#000018] text-white border-[#00FFFF] animate-in fade-in-50 duration-300 space-theme font-mono cursor-galaga overflow-y-auto p-0 max-h-[90vh]"
           style={{ boxShadow: "0 0 20px rgba(0, 255, 255, 0.5)", border: "2px solid #00FFFF" }}
           role="dialog"
           aria-labelledby="table-dialog-title"


### PR DESCRIPTION
## Summary
- better detect older iPads and disable heavy animations
- constrain table dialog height on tablets

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68786df8c0b08329995b99b620eaacf9