### PR TITLE
Support quick starting tables

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -432,7 +432,11 @@ export function BilliardsTimerDashboard() {
     dispatch({ type: "SET_STATE", payload: { selectedTable: null } });
   }, []);
 
-  const { startTableSession, endTableSession } = useTableActions({
+  const {
+    startTableSession,
+    quickStartTableSession,
+    endTableSession,
+  } = useTableActions({
     tables: state.tables, // Use tables from state
     dispatch,
     debouncedUpdateTable: queueTableUpdate,
@@ -1315,6 +1319,10 @@ export function BilliardsTimerDashboard() {
                   servers={memoizedServers}
                   logs={memoizedLogs}
                   onTableClick={openTableDialog}
+                  onQuickStartSession={quickStartTableSession}
+                  onQuickEndSession={confirmEndSession}
+                  canQuickStart={hasPermission("canQuickStart")}
+                  canEndSession={hasPermission("canEndSession")}
                   // showAnimations={settings.showTableCardAnimations} // Already passed to EnhancedMobileTableList
                 />
               )}

--- a/components/tables/table-grid.tsx
+++ b/components/tables/table-grid.tsx
@@ -34,6 +34,8 @@ interface TableGridProps {
   onTableClick: (table: Table) => void
   onQuickStartSession?: (tableId: number) => void
   onQuickEndSession?: (tableId: number) => void
+  canQuickStart?: boolean
+  canEndSession?: boolean
 }
 
 // Define layout configuration for flexibility
@@ -61,6 +63,8 @@ function TableGridComponent({
   onTableClick,
   onQuickStartSession,
   onQuickEndSession,
+  canQuickStart,
+  canEndSession,
 }: TableGridProps) {
   // Memoize the table lookup map for performance
   const tableMap = useMemo(() => {
@@ -130,7 +134,7 @@ function TableGridComponent({
             }}
             role="gridcell"
           >
-            {onQuickStartSession && onQuickEndSession ? (
+            {onQuickStartSession || onQuickEndSession ? (
               <SwipeableTableCard
                 table={table}
                 servers={servers}
@@ -140,8 +144,8 @@ function TableGridComponent({
                 onQuickStart={onQuickStartSession}
                 onEndSession={onQuickEndSession}
                 canAddTime={false}
-                canQuickStart={!!onQuickStartSession}
-                canEndSession={!!onQuickEndSession}
+                canQuickStart={canQuickStart}
+                canEndSession={canEndSession}
               />
             ) : (
               <TableCard

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -7,6 +7,7 @@ import { type UserRole, ADMIN_LEVEL_ROLES } from "@/types/user"
 // Define user roles and permissions
 interface Permission {
   canStartSession: boolean
+  canQuickStart: boolean
   canEndSession: boolean
   canAddTime: boolean
   canSubtractTime: boolean

--- a/services/supabase-auth-service.ts
+++ b/services/supabase-auth-service.ts
@@ -6,57 +6,57 @@ import { type UserRole, type User, type Permission, ADMIN_LEVEL_ROLES, USER_ROLE
 // Define default permissions for each role (remains here as it's service-specific default logic)
 const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   admin: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   controller: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   manager: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   server: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: false,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: false,
     canUpdateGuests: true, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: true, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   bartender: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   barback: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   kitchen: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   security: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   karaoke_main: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   karaoke_staff: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   viewer: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -3,6 +3,7 @@ import { createClient } from "@supabase/supabase-js"
 
 export interface Permission {
   canStartSession: boolean
+  canQuickStart: boolean
   canEndSession: boolean
   canAddTime: boolean
   canSubtractTime: boolean
@@ -31,6 +32,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   // Admin level roles - full access
   admin: {
     canStartSession: true,
+    canQuickStart: true,
     canEndSession: true,
     canAddTime: true,
     canSubtractTime: true,
@@ -46,6 +48,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   controller: {
     canStartSession: true,
+    canQuickStart: true,
     canEndSession: true,
     canAddTime: true,
     canSubtractTime: true,
@@ -61,6 +64,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   manager: {
     canStartSession: true,
+    canQuickStart: true,
     canEndSession: true,
     canAddTime: true,
     canSubtractTime: true,
@@ -77,6 +81,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   // Staff level roles - operational access
   server: {
     canStartSession: true,
+    canQuickStart: true,
     canEndSession: true,
     canAddTime: true,
     canSubtractTime: false,
@@ -92,6 +97,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   bartender: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -107,6 +113,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   barback: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -122,6 +129,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   kitchen: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -137,6 +145,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   security: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -152,6 +161,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   karaoke_main: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -167,6 +177,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   },
   karaoke_staff: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,
@@ -183,6 +194,7 @@ export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   // View only role
   viewer: {
     canStartSession: false,
+    canQuickStart: false,
     canEndSession: false,
     canAddTime: false,
     canSubtractTime: false,

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,6 +1,7 @@
 // Defines the shape of a permission set
 export interface Permission {
   canStartSession: boolean;
+  canQuickStart: boolean;
   canEndSession: boolean;
   canAddTime: boolean;
   canSubtractTime: boolean;
@@ -81,58 +82,58 @@ export const VIEW_ONLY_ROLES: UserRole[] = ["viewer"];
 // Default permissions by role
 export const DEFAULT_PERMISSIONS: Record<UserRole, Permission> = {
   admin: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   controller: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   manager: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: true,
     canUpdateGuests: true, canAssignServer: true, canGroupTables: true, canUngroupTable: true,
     canMoveTable: true, canUpdateNotes: true, canViewLogs: true, canManageUsers: true, canManageSettings: true,
   },
   server: {
-    canStartSession: true, canEndSession: true, canAddTime: true, canSubtractTime: false,
-    canUpdateGuests: true, canAssignServer: false, 
+    canStartSession: true, canQuickStart: true, canEndSession: true, canAddTime: true, canSubtractTime: false,
+    canUpdateGuests: true, canAssignServer: false,
     canGroupTables: false, canUngroupTable: false, canMoveTable: false,
     canUpdateNotes: true, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   bartender: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   barback: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   kitchen: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   security: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   karaoke_main: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   karaoke_staff: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },
   viewer: {
-    canStartSession: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
+    canStartSession: false, canQuickStart: false, canEndSession: false, canAddTime: false, canSubtractTime: false,
     canUpdateGuests: false, canAssignServer: false, canGroupTables: false, canUngroupTable: false,
     canMoveTable: false, canUpdateNotes: false, canViewLogs: false, canManageUsers: false, canManageSettings: false,
   },


### PR DESCRIPTION
## Summary
- pass quickStartTableSession and confirmEndSession actions into TableGrid
- propagate new canQuickStart and canEndSession flags
- extend Permission definitions with canQuickStart
- include default values for all services

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878a53b49888329b48f0103444c2cbe