### PR TITLE
Implement portal-based number pad

### DIFF
--- a/components/auth/number-pad.tsx
+++ b/components/auth/number-pad.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import { XIcon } from "lucide-react"
 import { Loader2 } from "lucide-react"
 
@@ -94,5 +96,56 @@ export function NumberPad({
         </Button>
       )}
     </div>
+  )
+}
+
+interface NumberPadDialogProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (value: string) => void
+  initialValue?: string
+  maxLength?: number
+  title?: string
+}
+
+export function NumberPadDialog({
+  open,
+  onClose,
+  onSubmit,
+  initialValue = "",
+  maxLength = 6,
+  title = "Enter Value",
+}: NumberPadDialogProps) {
+  const [value, setValue] = useState(initialValue)
+
+  useEffect(() => {
+    if (open) {
+      setValue(initialValue)
+    }
+  }, [initialValue, open])
+
+  const handleDone = () => {
+    onSubmit(value)
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[300px] bg-black text-white border-[#00FFFF] space-theme font-mono">
+        <DialogHeader>
+          <DialogTitle className="text-lg text-[#00FFFF]">{title}</DialogTitle>
+        </DialogHeader>
+        <NumberPad value={value} onChange={setValue} maxLength={maxLength} />
+        <DialogFooter className="pt-2">
+          <Button
+            variant="outline"
+            onClick={handleDone}
+            className="w-full border-[#00FFFF] bg-[#000033] hover:bg-[#000066] text-[#00FFFF]"
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -21,7 +21,7 @@ import type { Table, Server, NoteTemplate, LogEntry } from "@/components/system/
 import { useAuth } from "@/contexts/auth-context"
 import type { User } from "@/types/user"; // Using User from types/user.ts
 import { TooltipProvider } from "@/components/ui/tooltip"
-import { NumberPad } from "@/components/auth/number-pad"
+import { NumberPadDialog } from "@/components/auth/number-pad"
 import { MenuRecommendations } from "@/components/system/menu-recommendations"
 import { useMobile } from "@/hooks/use-mobile"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
@@ -1028,12 +1028,12 @@ export function TableDialog({
         </DialogContent>
       </Dialog>
       {showNumberPad && (
-        <NumberPad
-          open={showNumberPad} // Prop to control dialog visibility
+        <NumberPadDialog
+          open={showNumberPad}
           onClose={() => setShowNumberPad(false)}
-          onSubmit={(val) => handleNumberPadInput(val)} // Ensure NumberPad onSubmit returns string
-          initialValue={String(guestCount)} // Pass as string
-          maxLength={2} // Max 2 digits for guest count up to 16
+          onSubmit={(val) => handleNumberPadInput(val)}
+          initialValue={String(guestCount)}
+          maxLength={2}
           title="Enter Guest Count"
         />
       )}


### PR DESCRIPTION
## Summary
- create `NumberPadDialog` component to show number pad inside a Radix dialog
- replace inline number pad in `TableDialog` with the new dialog variant

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878c3cf4fc083298efabddc2e9d9ae3