### PR TITLE
Enable optional table timer RAF updates

### DIFF
--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -246,6 +246,7 @@ export function BilliardsTimerDashboard() {
   
   // *** MODIFICATION: Mounted state for reliable client-side checks ***
   const [hasMounted, setHasMounted] = useState(false);
+  const [isOldIpad, setIsOldIpad] = useState(false);
   const isMobile = useMobile(); // This hook should now return undefined initially
 
   useEffect(() => {
@@ -256,11 +257,12 @@ export function BilliardsTimerDashboard() {
     if (!hasMounted) return;
     const ua = navigator.userAgent;
     // Broaden older iPad detection to include up to iPadOS 15
-    const isOldIpad = /iPad/.test(ua) && /OS 1[3-5]_/.test(ua);
-    if (isOldIpad) {
+    const oldIpad = /iPad/.test(ua) && /OS 1[3-5]_/.test(ua);
+    setIsOldIpad(oldIpad);
+    if (oldIpad) {
       dispatch({ type: "UPDATE_SETTINGS", payload: { showTableCardAnimations: false } });
     }
-  }, [hasMounted]);
+  }, [hasMounted, dispatch]);
 
   const {
     tables, // This will be from dashboardReducer state
@@ -313,6 +315,7 @@ export function BilliardsTimerDashboard() {
   const memoizedTables = useMemo(() => tables, [tables]);
   const memoizedServers = useMemo(() => servers, [servers]);
   const memoizedLogs = useMemo(() => logs, [logs]);
+  const tableCardAnimations = settings.showTableCardAnimations && !isOldIpad;
 
   // Update hideSystemElements based on isMobile, only after component has mounted
   useEffect(() => {
@@ -1309,7 +1312,7 @@ export function BilliardsTimerDashboard() {
                           onOpenQuickStartDialog={openQuickStartDialog}
                           canEndSession={hasPermission("canEndSession")}
                           onRefresh={handleRefreshData}
-                          showAnimations={settings.showTableCardAnimations}
+                          showAnimations={tableCardAnimations}
                         />
                       </div>
                     )}
@@ -1345,7 +1348,7 @@ export function BilliardsTimerDashboard() {
                   onQuickEndSession={confirmEndSession}
                   canQuickStart={hasPermission("canQuickStart")}
                   canEndSession={hasPermission("canEndSession")}
-                  // showAnimations={settings.showTableCardAnimations} // Already passed to EnhancedMobileTableList
+                  showAnimations={tableCardAnimations}
                 />
               )}
             </OrientationAwareContainer>

--- a/components/tables/table-card.tsx
+++ b/components/tables/table-card.tsx
@@ -157,7 +157,7 @@ const TableCardComponent = function TableCard({
   const cardRef = useRef<HTMLDivElement>(null)
   const particlesRef = useRef<HTMLCanvasElement>(null)
 
-  const timer = useTableTimer(localTable)
+  const timer = useTableTimer(localTable, showAnimations)
 
   useEffect(() => {
     setLocalTable(storeTable)

--- a/components/tables/table-grid.tsx
+++ b/components/tables/table-grid.tsx
@@ -36,6 +36,7 @@ interface TableGridProps {
   onQuickEndSession?: (tableId: number) => void
   canQuickStart?: boolean
   canEndSession?: boolean
+  showAnimations?: boolean
 }
 
 // Define layout configuration for flexibility
@@ -65,6 +66,7 @@ function TableGridComponent({
   onQuickEndSession,
   canQuickStart,
   canEndSession,
+  showAnimations = true,
 }: TableGridProps) {
   // Memoize the table lookup map for performance
   const tableMap = useMemo(() => {
@@ -144,6 +146,7 @@ function TableGridComponent({
                 onEndSession={onQuickEndSession}
                 canQuickStart={canQuickStart}
                 canEndSession={canEndSession}
+                showAnimations={showAnimations}
               />
             ) : (
               <TableCard
@@ -158,6 +161,7 @@ function TableGridComponent({
                   }
                 }}
                 tabIndex={0}
+                showAnimations={showAnimations}
               />
             )}
           </div>

--- a/components/tables/table-timer-display.tsx
+++ b/components/tables/table-timer-display.tsx
@@ -26,7 +26,7 @@ export function TableTimerDisplay({
   isWarningYellow,
   showAnimations = true,
 }: TableTimerDisplayProps) {
-  const timer = useTableTimer(table); // The hook now lives here
+  const timer = useTableTimer(table, showAnimations); // The hook now lives here
 
   const getTimerTextColor = useMemo(() => {
     if (isOvertime || isCritical) return "#FF4500"; // Bright Red-Orange

--- a/hooks/use-table-timer.ts
+++ b/hooks/use-table-timer.ts
@@ -7,8 +7,7 @@ import type { Table } from "@/components/system/billiards-timer-dashboard" // Ad
 // Simplified Table type for the hook, ensuring it has what it needs.
 // The consuming component will pass the full Table type.
 type HookTableInput = Pick<Table, "id" | "isActive" | "startTime" | "initialTime" | "remainingTime">
-
-export function useTableTimer(table: HookTableInput) {
+export function useTableTimer(table: HookTableInput, useRAF = true) {
   // Initialize remainingTime:
   // - If active and has startTime, calculate current remaining.
   // - If active but no startTime (e.g., session started but data not fully synced), use table.remainingTime.
@@ -107,6 +106,14 @@ export function useTableTimer(table: HookTableInput) {
 
   // Local animation loop to update the timer every frame while active
   useEffect(() => {
+    if (!useRAF) {
+      if (animationFrameIdRef.current !== null) {
+        cancelAnimationFrame(animationFrameIdRef.current)
+        animationFrameIdRef.current = null
+      }
+      return
+    }
+
     const runAnimation = () => {
       tick(Date.now())
       animationFrameIdRef.current = requestAnimationFrame(runAnimation)
@@ -122,7 +129,7 @@ export function useTableTimer(table: HookTableInput) {
         animationFrameIdRef.current = null
       }
     }
-  }, [table.isActive, table.startTime, tick])
+  }, [table.isActive, table.startTime, tick, useRAF])
 
   // Exposed formatTime function (re-wrapped for stability if formatTimeUtil is stable)
   const formatTime = useCallback(


### PR DESCRIPTION
## Summary
- let `useTableTimer` skip requestAnimationFrame when desired
- forward `showAnimations` state down into table timers
- disable animations on older iPads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e00838c088329bfbfae102473bf0f