### PR TITLE
Improve table card layout

### DIFF
--- a/components/tables/swipeable-table-card.tsx
+++ b/components/tables/swipeable-table-card.tsx
@@ -364,8 +364,8 @@ export function SwipeableTableCard({
       {/* Right action indicator (Quick Start) */}
       {!table.isActive && canQuickStart && (
         <div
-          className={`absolute right-0 top-0 bottom-0 w-20 flex items-center justify-center bg-gradient-to-r from-green-500 to-green-600 text-white z-10 ${
-            showRightAction ? "opacity-100" : "opacity-70"
+          className={`absolute right-0 top-0 bottom-0 w-20 flex items-center justify-center bg-gradient-to-r from-green-500/80 to-green-600/80 text-white z-10 ${
+            showRightAction ? "opacity-100" : "opacity-50"
           }`}
         >
           <div className="flex flex-col items-center">

--- a/components/tables/table-card.tsx
+++ b/components/tables/table-card.tsx
@@ -655,13 +655,19 @@ const TableCardComponent = function TableCard({
                 )}
               </div>
               {localTable.isActive && localTable.hasNotes && localTable.noteText && (
-                <div className="flex items-center gap-1.5 w-full animate-slide-in">
+                <div className="flex items-center gap-1.5 w-full animate-slide-in overflow-hidden">
                   <div className="bg-[#FFFF00]/30 p-1 rounded-full">
                     <MessageSquareIcon className="h-3 w-3 flex-shrink-0 text-[#FFFF00]" />
                   </div>
                   <span
-                    className="truncate w-full text-white text-[10px] sm:text-xs"
-                    style={{ textShadow: "0 0 4px rgba(255, 255, 0, 0.7)" }}
+                    className="w-full text-white text-[10px] sm:text-xs break-words"
+                    style={{
+                      textShadow: "0 0 4px rgba(255, 255, 0, 0.7)",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                      overflow: "hidden",
+                    }}
                   >
                     {localTable.noteText}
                   </span>


### PR DESCRIPTION
## Summary
- prevent long notes from stretching table cards
- dim the Quick Start swipe action background

## Testing
- `npm run lint`
- `npm run build` *(fails: Invalid URL / missing config)*

------
https://chatgpt.com/codex/tasks/task_e_687e03f4bf048329883b5bc7b42e1b8f