### PR TITLE
Add long-press actions and dialogs

### DIFF
--- a/components/dialogs/quick-note-dialog.tsx
+++ b/components/dialogs/quick-note-dialog.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import type { Table } from "@/components/system/billiards-timer-dashboard"
+
+interface QuickNoteDialogProps {
+  open: boolean
+  onClose: () => void
+  table: Table | null
+  onSave: (tableId: number, noteText: string) => void
+}
+
+export function QuickNoteDialog({ open, onClose, table, onSave }: QuickNoteDialogProps) {
+  const [note, setNote] = useState("")
+
+  useEffect(() => {
+    if (open) {
+      setNote(table?.noteText || "")
+    }
+  }, [open, table])
+
+  const handleSave = () => {
+    if (table) {
+      onSave(table.id, note)
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[400px] bg-black text-white border-[#00FFFF] space-theme font-mono">
+        <DialogHeader>
+          <DialogTitle className="text-lg text-[#00FFFF]">Quick Note: {table?.name}</DialogTitle>
+        </DialogHeader>
+        <div className="py-2 space-y-2">
+          <Textarea value={note} onChange={(e) => setNote(e.target.value)} className="bg-[#000033] border-[#00FFFF] text-white" />
+        </div>
+        <DialogFooter className="flex justify-between">
+          <Button variant="outline" onClick={onClose} className="border-[#00FFFF] bg-[#000033] hover:bg-[#000066] text-[#00FFFF]">Cancel</Button>
+          <Button onClick={handleSave} className="bg-[#00FFFF] hover:bg-[#00CCCC] text-black">Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/dialogs/status-indicator-dialog.tsx
+++ b/components/dialogs/status-indicator-dialog.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import type { Table } from "@/components/system/billiards-timer-dashboard"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+interface StatusIndicatorDialogProps {
+  open: boolean
+  onClose: () => void
+  table: Table | null
+}
+
+export function StatusIndicatorDialog({ open, onClose, table }: StatusIndicatorDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-[300px] bg-black text-white border-[#00FFFF] space-theme font-mono">
+        <DialogHeader>
+          <DialogTitle className="text-lg text-[#00FFFF]">Status: {table?.name}</DialogTitle>
+        </DialogHeader>
+        <div className="py-2 space-y-1 text-sm">
+          <div>Active: {table?.isActive ? "Yes" : "No"}</div>
+          <div>Guest Count: {table?.guestCount}</div>
+          <div>Server: {table?.server || "None"}</div>
+          {table?.groupId && <div>Group: {table.groupId}</div>}
+          {table?.hasNotes && <div>Note: {table.noteText}</div>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} className="border-[#00FFFF] bg-[#000033] hover:bg-[#000066] text-[#00FFFF] w-full">Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -15,6 +15,8 @@ import { SessionFeedbackDialog } from "@/components/dialogs/session-feedback-dia
 import { Header } from "@/components/layout/header";
 import { TableGrid } from "@/components/tables/table-grid";
 import { QuickStartDialog } from "@/components/dialogs/quick-start-dialog";
+import { QuickNoteDialog } from "@/components/dialogs/quick-note-dialog";
+import { StatusIndicatorDialog } from "@/components/dialogs/status-indicator-dialog";
 import { ConfirmDialog } from "@/components/dialogs/confirm-dialog";
 import { TouchLogin } from "@/components/auth/touch-login";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -97,6 +99,8 @@ interface DashboardState {
   settings: SystemSettings;
   selectedTable: Table | null;
   showQuickStartDialog: boolean;
+  showQuickNoteDialog: boolean;
+  showStatusDialog: boolean;
   showLoginDialog: boolean;
   showUserManagementDialog: boolean;
   showSettingsDialog: boolean;
@@ -177,6 +181,8 @@ const initialState: DashboardState = {
   },
   selectedTable: null,
   showQuickStartDialog: false,
+  showQuickNoteDialog: false,
+  showStatusDialog: false,
   showLoginDialog: false,
   showUserManagementDialog: false,
   showSettingsDialog: false,
@@ -273,6 +279,8 @@ export function BilliardsTimerDashboard() {
     settings,
     selectedTable,
     showQuickStartDialog,
+    showQuickNoteDialog,
+    showStatusDialog,
     showLoginDialog,
     showUserManagementDialog,
     showSettingsDialog,
@@ -623,6 +631,44 @@ export function BilliardsTimerDashboard() {
     },
     [state.tables]
   );
+
+  const openQuickNoteDialog = useCallback(
+    (tableId: number) => {
+      const table = state.tables.find((t) => t.id === tableId);
+      if (!table) return;
+      dispatch({
+        type: "SET_STATE",
+        payload: { selectedTable: table, showQuickNoteDialog: true },
+      });
+    },
+    [state.tables]
+  );
+
+  const closeQuickNoteDialog = useCallback(() => {
+    dispatch({
+      type: "SET_STATE",
+      payload: { selectedTable: null, showQuickNoteDialog: false },
+    });
+  }, []);
+
+  const openStatusDialog = useCallback(
+    (tableId: number) => {
+      const table = state.tables.find((t) => t.id === tableId);
+      if (!table) return;
+      dispatch({
+        type: "SET_STATE",
+        payload: { selectedTable: table, showStatusDialog: true },
+      });
+    },
+    [state.tables]
+  );
+
+  const closeStatusDialog = useCallback(() => {
+    dispatch({
+      type: "SET_STATE",
+      payload: { selectedTable: null, showStatusDialog: false },
+    });
+  }, []);
 
   const closeQuickStartDialog = useCallback(() => {
     dispatch({
@@ -1013,6 +1059,14 @@ export function BilliardsTimerDashboard() {
     [state.tables, addLogEntry, showNotification, queueTableUpdate, dispatch] // Use state
   );
 
+  const handleQuickNoteSave = useCallback(
+    (tableId: number, noteText: string) => {
+      updateTableNotes(tableId, "", noteText)
+      closeQuickNoteDialog()
+    },
+    [updateTableNotes, closeQuickNoteDialog]
+  )
+
   const getServerName = useCallback(
     (serverId: string | null) => {
       if (!serverId) return "Unassigned";
@@ -1345,6 +1399,10 @@ export function BilliardsTimerDashboard() {
                   logs={memoizedLogs}
                   onTableClick={openTableDialog}
                   onOpenQuickStartDialog={openQuickStartDialog}
+                  onOpenQuickNoteDialog={openQuickNoteDialog}
+                  onOpenStatusDialog={openStatusDialog}
+                  onMoveRequest={(id) => openTableDialog(memoizedTables.find(t => t.id === id) as Table)}
+                  onGroupRequest={(id) => openTableDialog(memoizedTables.find(t => t.id === id) as Table)}
                   onQuickEndSession={confirmEndSession}
                   canQuickStart={hasPermission("canQuickStart")}
                   canEndSession={hasPermission("canEndSession")}
@@ -1391,6 +1449,23 @@ export function BilliardsTimerDashboard() {
               quickStartTableSession(selectedTable.id, guestCount, serverId)
               closeQuickStartDialog()
             }}
+          />
+        )}
+
+        {selectedTable && showQuickNoteDialog && (
+          <QuickNoteDialog
+            open={showQuickNoteDialog}
+            onClose={closeQuickNoteDialog}
+            table={selectedTable}
+            onSave={handleQuickNoteSave}
+          />
+        )}
+
+        {selectedTable && showStatusDialog && (
+          <StatusIndicatorDialog
+            open={showStatusDialog}
+            onClose={closeStatusDialog}
+            table={selectedTable}
           />
         )}
         

--- a/components/tables/table-grid.tsx
+++ b/components/tables/table-grid.tsx
@@ -33,6 +33,10 @@ interface TableGridProps {
   logs: LogEntry[]
   onTableClick: (table: Table) => void
   onOpenQuickStartDialog?: (tableId: number) => void
+  onOpenQuickNoteDialog?: (tableId: number) => void
+  onOpenStatusDialog?: (tableId: number) => void
+  onMoveRequest?: (tableId: number) => void
+  onGroupRequest?: (tableId: number) => void
   onQuickEndSession?: (tableId: number) => void
   canQuickStart?: boolean
   canEndSession?: boolean
@@ -63,6 +67,10 @@ function TableGridComponent({
   logs = [],
   onTableClick,
   onOpenQuickStartDialog,
+  onOpenQuickNoteDialog,
+  onOpenStatusDialog,
+  onMoveRequest,
+  onGroupRequest,
   onQuickEndSession,
   canQuickStart,
   canEndSession,
@@ -143,6 +151,10 @@ function TableGridComponent({
                 logs={logs}
                 onClick={() => handleTableClick(table)}
                 onOpenQuickStartDialog={onOpenQuickStartDialog}
+                onOpenQuickNoteDialog={onOpenQuickNoteDialog}
+                onOpenStatusDialog={onOpenStatusDialog}
+                onMoveRequest={onMoveRequest}
+                onGroupRequest={onGroupRequest}
                 onEndSession={onQuickEndSession}
                 canQuickStart={canQuickStart}
                 canEndSession={canEndSession}


### PR DESCRIPTION
## Summary
- introduce `QuickNoteDialog` and `StatusIndicatorDialog`
- add long‑press menu and new swipe logic to table cards
- allow table grid to forward menu callbacks
- wire quick note/status dialogs into dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e067aebfc8329960f2af3acc2e932