### PR TITLE
Fix number pad submission logic

### DIFF
--- a/components/tables/table-dialog.tsx
+++ b/components/tables/table-dialog.tsx
@@ -529,10 +529,11 @@ export function TableDialog({
     setTimeout(() => { touchInProgressRef.current = false }, 100);
   }, [updateGuestCountOptimistically]);
 
-  const handleNumberPadInput = useCallback(
-    (value: string) => { // NumberPad now returns string
-      const newCount = Math.min(16, Math.max(0, parseInt(value, 10) || 0));
-      updateGuestCountOptimistically(newCount);
+const handleNumberPadInput = useCallback(
+    (value: string) => {
+      const num = Math.min(16, Math.max(0, parseInt(value, 10) || 0));
+      setGuestCount(num);
+      updateGuestCountOptimistically(num);
       setShowNumberPad(false);
     },
     [updateGuestCountOptimistically],


### PR DESCRIPTION
## Summary
- ensure TableDialog saves number pad values directly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e1341ac9c83298a56242bf3b98ffd