### PR TITLE
Implement table long-press dialog and remove fullscreen control

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,8 +4,6 @@ import { useState, useEffect } from "react"
 import {
   Settings,
   LogOut,
-  Maximize,
-  Minimize,
   User,
   PlayCircle,
   StopCircle,
@@ -28,7 +26,6 @@ interface HeaderProps {
   onLogout: () => void
   onLogin: () => void
   onSync: () => void
-  onToggleFullScreen: () => void
   onShowFunctions: () => void
   tables: Table[]
   logs: LogEntry[]
@@ -48,7 +45,6 @@ export function Header({
   onLogout,
   onLogin,
   onSync,
-  onToggleFullScreen,
   onShowFunctions,
   tables,
   logs,
@@ -56,36 +52,9 @@ export function Header({
   animationComplete,
 }: HeaderProps) {
   const [isSyncing, setIsSyncing] = useState(false)
-  const [isFullScreen, setIsFullScreen] = useState(false)
   const [activeTables, setActiveTables] = useState(0)
   const [currentTimeString, setCurrentTimeString] = useState("")
   const [currentDateString, setCurrentDateString] = useState("")
-
-  // Check if fullscreen is active
-  useEffect(() => {
-    const handleFullScreenChange = () => {
-      setIsFullScreen(
-        !!(
-          document.fullscreenElement ||
-          (document as any).webkitFullscreenElement ||
-          (document as any).mozFullscreenElement ||
-          (document as any).msFullscreenElement
-        ),
-      )
-    }
-
-    document.addEventListener("fullscreenchange", handleFullScreenChange)
-    document.addEventListener("webkitfullscreenchange", handleFullScreenChange)
-    document.addEventListener("mozfullscreenchange", handleFullScreenChange)
-    document.addEventListener("MSFullscreenChange", handleFullScreenChange)
-
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullScreenChange)
-      document.removeEventListener("webkitfullscreenchange", handleFullScreenChange)
-      document.removeEventListener("mozfullscreenchange", handleFullScreenChange)
-      document.removeEventListener("MSFullscreenChange", handleFullScreenChange)
-    }
-  }, [])
 
   // Update active tables count
   useEffect(() => {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -196,18 +196,6 @@ export function Header({
               <Function className="h-4 w-4 text-gray-400" />
             </Button>
 
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-8 w-8 border-cyan-700 bg-black/60 hover:bg-cyan-950 hover:text-cyan-400 lg:flex hidden"
-              onClick={onToggleFullScreen}
-            >
-              {isFullScreen ? (
-                <Minimize className="h-4 w-4 text-gray-400" />
-              ) : (
-                <Maximize className="h-4 w-4 text-gray-400" />
-              )}
-            </Button>
 
             <Button
               variant="outline"

--- a/components/tables/swipeable-table-card.tsx
+++ b/components/tables/swipeable-table-card.tsx
@@ -78,6 +78,7 @@ export function SwipeableTableCard({
 
   // Handle touch start
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    e.preventDefault()
     // Store the initial touch position
     startXRef.current = e.touches[0].clientX
     startYRef.current = e.touches[0].clientY
@@ -185,6 +186,19 @@ export function SwipeableTableCard({
   const handleTouchEnd = useCallback(() => {
     if (!touchStartedRef.current) return
     touchStartedRef.current = false
+
+    if (showActionDialog) {
+      if (longPressTimeoutRef.current) {
+        clearTimeout(longPressTimeoutRef.current)
+        longPressTimeoutRef.current = null
+      }
+      setSwipeOffset(0)
+      setIsSwiping(false)
+      isSwipingRef.current = false
+      isScrollingVerticallyRef.current = false
+      swipeDirectionDeterminedRef.current = false
+      return
+    }
 
     // If we were scrolling vertically, just reset and return
     if (isScrollingVerticallyRef.current) {
@@ -405,6 +419,10 @@ export function SwipeableTableCard({
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
+    if (showActionDialog) {
+      // If the long-press menu is showing, ignore click
+      return
+    }
     setMenuPosition(null)
     onClick()
   }
@@ -412,11 +430,12 @@ export function SwipeableTableCard({
   return (
     <div
       className={`relative swipeable-card-container ${className}`}
-      style={{ touchAction: "pan-y", userSelect: "none" }}
+      style={{ touchAction: "pan-y", userSelect: "none", WebkitTapHighlightColor: "transparent" }}
       ref={containerRef}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
+      onContextMenu={(e) => e.preventDefault()}
     >
       {/* Left action indicator */}
       {(table.isActive && canEndSession) || (!table.isActive && onOpenStatusDialog) ? (


### PR DESCRIPTION
## Summary
- remove the fullscreen toggle button from the header
- show a dialog with Move/Group/Add Status options when long‑pressing a table card

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e1c5104488329b5c03589b0fa7fdc