### PR TITLE
Add new table status badges and enhance Quick Note

### DIFF
--- a/components/dialogs/quick-note-dialog.tsx
+++ b/components/dialogs/quick-note-dialog.tsx
@@ -4,21 +4,28 @@ import { useState, useEffect } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
-import type { Table } from "@/components/system/billiards-timer-dashboard"
+import type { Table, NoteTemplate } from "@/components/system/billiards-timer-dashboard"
+import { statusOptions } from "./status-indicator-dialog"
 
 interface QuickNoteDialogProps {
   open: boolean
   onClose: () => void
   table: Table | null
+  noteTemplates: NoteTemplate[]
   onSave: (tableId: number, noteText: string) => void
+  onUpdateStatus: (tableId: number, statuses: string[]) => void
 }
 
-export function QuickNoteDialog({ open, onClose, table, onSave }: QuickNoteDialogProps) {
+export function QuickNoteDialog({ open, onClose, table, noteTemplates, onSave, onUpdateStatus }: QuickNoteDialogProps) {
   const [note, setNote] = useState("")
+  const [selectedNoteId, setSelectedNoteId] = useState<string>("")
+  const [statuses, setStatuses] = useState<string[]>([])
 
   useEffect(() => {
     if (open) {
       setNote(table?.noteText || "")
+      setSelectedNoteId(table?.noteId || "")
+      setStatuses(table?.statusIndicators || [])
     }
   }, [open, table])
 
@@ -29,6 +36,20 @@ export function QuickNoteDialog({ open, onClose, table, onSave }: QuickNoteDialo
     }
   }
 
+  const handleTemplateSelect = (id: string) => {
+    setSelectedNoteId(id)
+    const template = noteTemplates.find((t) => t.id === id)
+    setNote(template?.text || "")
+  }
+
+  const toggleStatus = (key: string) => {
+    if (!table) return
+    const exists = statuses.includes(key)
+    const updated = exists ? statuses.filter((s) => s !== key) : [...statuses, key]
+    setStatuses(updated)
+    onUpdateStatus(table.id, updated)
+  }
+
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
       <DialogContent className="sm:max-w-[400px] bg-black text-white border-[#00FFFF] space-theme font-mono">
@@ -36,7 +57,53 @@ export function QuickNoteDialog({ open, onClose, table, onSave }: QuickNoteDialo
           <DialogTitle className="text-lg text-[#00FFFF]">Quick Note: {table?.name}</DialogTitle>
         </DialogHeader>
         <div className="py-2 space-y-2">
-          <Textarea value={note} onChange={(e) => setNote(e.target.value)} className="bg-[#000033] border-[#00FFFF] text-white" />
+          <Textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="bg-[#000033] border-[#00FFFF] text-white"
+          />
+          {noteTemplates.length > 0 && (
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                variant={selectedNoteId === "" ? "default" : "outline"}
+                className={selectedNoteId === "" ? "w-full bg-[#FFFF00] text-black active:scale-95" : "w-full border-[#FFFF00] text-[#FFFF00] active:scale-95"}
+                onClick={() => handleTemplateSelect("")}
+              >
+                No Note
+              </Button>
+              {noteTemplates.map((note) => (
+                <Button
+                  key={note.id}
+                  variant={selectedNoteId === note.id ? "default" : "outline"}
+                  className={selectedNoteId === note.id ? "w-full bg-[#FFFF00] text-black active:scale-95" : "w-full border-[#FFFF00] text-[#FFFF00] active:scale-95"}
+                  onClick={() => handleTemplateSelect(note.id)}
+                >
+                  {note.text.length > 15 ? note.text.substring(0, 15) + "..." : note.text}
+                </Button>
+              ))}
+            </div>
+          )}
+          {selectedNoteId && (
+            <div className="p-2 bg-[#111100] rounded-md border border-[#FFFF00]/50">
+              <p className="text-[#FFFF00]">
+                {noteTemplates.find((n) => n.id === selectedNoteId)?.text || ""}
+              </p>
+            </div>
+          )}
+          {table?.isActive && (
+            <div className="grid grid-cols-2 gap-2 pt-2">
+              {statusOptions.map(({ key, icon: Icon, label }) => (
+                <Button
+                  key={key}
+                  variant={statuses.includes(key) ? "default" : "outline"}
+                  onClick={() => toggleStatus(key)}
+                  className="flex items-center gap-1 px-2 py-1 text-xs"
+                >
+                  <Icon className="h-4 w-4" /> {label}
+                </Button>
+              ))}
+            </div>
+          )}
         </div>
         <DialogFooter className="flex justify-between">
           <Button variant="outline" onClick={onClose} className="border-[#00FFFF] bg-[#000033] hover:bg-[#000066] text-[#00FFFF]">Cancel</Button>

--- a/components/dialogs/status-indicator-dialog.tsx
+++ b/components/dialogs/status-indicator-dialog.tsx
@@ -3,7 +3,18 @@
 import type { Table } from "@/components/system/billiards-timer-dashboard"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { Beer, Utensils, Bell, SprayCan } from "lucide-react"
+import {
+  Beer,
+  Utensils,
+  Bell,
+  SprayCan,
+  CalendarCheck,
+  DollarSign,
+  Baby,
+  Ban,
+  Angry,
+  Star,
+} from "lucide-react"
 
 interface StatusIndicatorDialogProps {
   open: boolean
@@ -12,11 +23,17 @@ interface StatusIndicatorDialogProps {
   onUpdateStatus: (tableId: number, statuses: string[]) => void
 }
 
-const statusOptions = [
+export const statusOptions = [
   { key: "service", icon: Bell, label: "Server" },
   { key: "drinks", icon: Beer, label: "Drinks" },
   { key: "food", icon: Utensils, label: "Food" },
   { key: "clean", icon: SprayCan, label: "Clean" },
+  { key: "reservation", icon: CalendarCheck, label: "Reservation" },
+  { key: "paid", icon: DollarSign, label: "Paid" },
+  { key: "under21", icon: Baby, label: "Under 21" },
+  { key: "noExtension", icon: Ban, label: "No Extension" },
+  { key: "sensitive", icon: Angry, label: "Sensitive" },
+  { key: "vip", icon: Star, label: "VIP" },
 ]
 
 export function StatusIndicatorDialog({ open, onClose, table, onUpdateStatus }: StatusIndicatorDialogProps) {

--- a/components/system/billiards-timer-dashboard.tsx
+++ b/components/system/billiards-timer-dashboard.tsx
@@ -1479,7 +1479,9 @@ export function BilliardsTimerDashboard() {
             open={showQuickNoteDialog}
             onClose={closeQuickNoteDialog}
             table={selectedTable}
+            noteTemplates={stateNoteTemplates}
             onSave={handleQuickNoteSave}
+            onUpdateStatus={updateTableStatuses}
           />
         )}
 

--- a/components/tables/table-status-badge.tsx
+++ b/components/tables/table-status-badge.tsx
@@ -1,7 +1,18 @@
 "use client"
 
 import React from "react"
-import { Beer, Utensils, Bell, SprayCan } from "lucide-react"
+import {
+  Beer,
+  Utensils,
+  Bell,
+  SprayCan,
+  CalendarCheck,
+  DollarSign,
+  Baby,
+  Ban,
+  Angry,
+  Star,
+} from "lucide-react"
 
 interface TableStatusBadgeProps {
   statuses?: string[]
@@ -12,6 +23,12 @@ const statusIconMap: Record<string, React.ReactNode> = {
   food: <Utensils className="h-4 w-4 text-yellow-400" />,
   service: <Bell className="h-4 w-4 text-blue-400" />,
   clean: <SprayCan className="h-4 w-4 text-green-400" />,
+  reservation: <CalendarCheck className="h-4 w-4 text-purple-400" />,
+  paid: <DollarSign className="h-4 w-4 text-green-300" />,
+  under21: <Baby className="h-4 w-4 text-pink-300" />,
+  noExtension: <Ban className="h-4 w-4 text-red-500" />,
+  sensitive: <Angry className="h-4 w-4 text-red-400" />,
+  vip: <Star className="h-4 w-4 text-yellow-400" />,
 }
 
 export function TableStatusBadge({ statuses = [] }: TableStatusBadgeProps) {


### PR DESCRIPTION
## Summary
- add more status badge icons
- export status options for dialogs
- show status toggles and note templates in Quick Note dialog
- wire up Quick Note dialog with new props

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687e286e93cc83299d6ee1e49ff80ccb