### PR TITLE
Fix table card alignment on iPad

### DIFF
--- a/app/ipad.css
+++ b/app/ipad.css
@@ -1,7 +1,7 @@
 /* iPad-specific optimizations */
 
 /* Detect iPad */
-@media (min-width: 768px) and (max-width: 1024px) {
+@media (pointer: coarse) and (min-width: 768px) and (max-width: 1366px) {
   /* Larger touch targets for iPad */
   button,
   .btn,
@@ -52,7 +52,7 @@
   }
 
   /* Landscape mode optimizations */
-  @media screen and (orientation: landscape) and (min-device-width: 768px) and (max-device-width: 1024px) {
+  @media screen and (orientation: landscape) and (min-device-width: 768px) and (max-device-width: 1366px) {
     .table-grid {
       /* Match desktop layout with six fixed columns */
       grid-template-columns: repeat(6, minmax(0, 1fr));

--- a/components/tables/table-card.tsx
+++ b/components/tables/table-card.tsx
@@ -630,7 +630,13 @@ const TableCardComponent = function TableCard({
             </div>
 
             <div className="flex flex-col gap-1.5 mt-auto text-xs bg-black/40 p-2 rounded-md backdrop-blur-sm overflow-visible mb-1">
-              <div className="flex justify-between items-center animate-fade-in">
+              <div
+                className={`flex items-center animate-fade-in ${
+                  localTable.isActive && localTable.server
+                    ? "justify-between"
+                    : "justify-center"
+                }`}
+              >
                 <div className="flex items-center gap-1.5">
                   <div className="bg-[#FF00FF]/30 p-1 rounded-full">
                     <UserIcon className="h-3.5 w-3.5 text-[#FF00FF]" />


### PR DESCRIPTION
## Summary
- center guest count text when no server is set on iPad
- widen iPad CSS media queries to include larger iPad widths

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f3d86e34483299e02b86e3d2b9bbc