### PR TITLE
Remove duplicate long-press cancel in swipe handler

### DIFF
--- a/components/tables/swipeable-table-card.tsx
+++ b/components/tables/swipeable-table-card.tsx
@@ -150,15 +150,6 @@ function SwipeableTableCardComponent({
         setShowActionDialog(false)
       }
 
-      if (absX > 10 || absY > 10) {
-        if (longPressTimeoutRef.current) {
-          clearTimeout(longPressTimeoutRef.current)
-          longPressTimeoutRef.current = null
-        }
-        setMenuPosition(null)
-        setShowActionDialog(false)
-      }
-
       // If we haven't determined the swipe direction yet, do it now
       if (!swipeDirectionDeterminedRef.current) {
         // If we've moved enough to determine direction


### PR DESCRIPTION
## Summary
- remove the repeated check that cleared the long-press timer in `handleTouchMove`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f464dcb908329b1e448a98aedd8f2