### PR TITLE
Fix mouse swipe by setting touchStartedRef

### DIFF
--- a/components/tables/swipeable-table-card.tsx
+++ b/components/tables/swipeable-table-card.tsx
@@ -307,6 +307,7 @@ function SwipeableTableCardComponent({
       startYRef.current = e.clientY
       currentXRef.current = e.clientX
       startTimeRef.current = Date.now()
+      touchStartedRef.current = true
       setIsSwiping(false)
       isSwipingRef.current = false
       isScrollingVerticallyRef.current = false


### PR DESCRIPTION
## Summary
- set `touchStartedRef` to `true` when a mouse swipe begins so mouse swiping behaves like touch swiping

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f47c7b3248329b4b270680432f69a