### PR TITLE
Adjust dialog width for iPad screens

### DIFF
--- a/app/ipad.css
+++ b/app/ipad.css
@@ -46,6 +46,11 @@
     pointer-events: auto;
   }
 
+  /* Limit dialog width so it doesn't stretch edge to edge */
+  .dialog-content {
+    max-width: 85vw;
+  }
+
   /* Allow dialogs more height on iPad */
   .table-dialog .dialog-content {
     max-height: 90vh !important;


### PR DESCRIPTION
## Summary
- limit dialog width on iPad so modals don't stretch across the screen

## Testing
- `npm run lint`
- `npm run build` *(fails: Invalid URL)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f537887dc8329b2d4df541332d15c