### PR TITLE
Fix dialog height units

### DIFF
--- a/app/dialog-fixes.css
+++ b/app/dialog-fixes.css
@@ -2,7 +2,7 @@
 @media (min-width: 768px) {
   /* Limit maximum height of all dialogs */
   .dialog-content {
-    max-height: 90vh !important;
+    max-height: calc(var(--vh, 1vh) * 90) !important;
     overflow-y: auto;
   }
 

--- a/app/ipad.css
+++ b/app/ipad.css
@@ -53,7 +53,7 @@
 
   /* Allow dialogs more height on iPad */
   .table-dialog .dialog-content {
-    max-height: 90vh !important;
+    max-height: calc(var(--vh, 1vh) * 90) !important;
   }
 
   /* Landscape mode optimizations */


### PR DESCRIPTION
## Summary
- use custom viewport unit in dialog CSS rules

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f59524a4c8329aec678028d65b3b2