### PR TITLE
Fix iOS touch listener cleanup

### DIFF
--- a/components/ios-touch-fix.tsx
+++ b/components/ios-touch-fix.tsx
@@ -29,14 +29,13 @@ export function IOSTouchFix() {
 
     // Fix for iOS momentum scrolling
     const scrollableElements = document.querySelectorAll(".ios-momentum-scroll")
+
+    const stopPropagation = (e: TouchEvent) => {
+      e.stopPropagation()
+    }
+
     scrollableElements.forEach((el) => {
-      el.addEventListener(
-        "touchmove",
-        (e) => {
-          e.stopPropagation()
-        },
-        { passive: true },
-      )
+      el.addEventListener("touchmove", stopPropagation, { passive: true })
     })
 
     // Fix for iOS safe areas
@@ -48,9 +47,7 @@ export function IOSTouchFix() {
     return () => {
       document.removeEventListener("touchend", preventDoubleTapZoom)
       scrollableElements.forEach((el) => {
-        el.removeEventListener("touchmove", (e) => {
-          e.stopPropagation()
-        })
+        el.removeEventListener("touchmove", stopPropagation)
       })
     }
   }, [])


### PR DESCRIPTION
## Summary
- ensure the touchmove listener added by `IOSTouchFix` is stored in a variable
- use that variable during cleanup so the event handler is removed correctly

## Testing
- `npx tsx /tmp/test-ios-touch-fix.ts` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_687f5d41715c83298fa4678c0a303cbe