### PR TITLE
Improve mobile touch handlers

### DIFF
--- a/components/mobile/touch-interaction-manager.tsx
+++ b/components/mobile/touch-interaction-manager.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from "react"
 
 export function TouchInteractionManager() {
-  const lastTouchEndRef = useRef(0)
   const touchStartCoordsRef = useRef<{ x: number; y: number } | null>(null)
 
   useEffect(() => {
@@ -74,7 +73,6 @@ export function TouchInteractionManager() {
 
     const handleTouchEnd = (e: TouchEvent) => {
       const target = e.target as HTMLElement
-      const now = Date.now()
 
       // Remove active states
       document.querySelectorAll(".touch-active").forEach((el) => {
@@ -92,25 +90,16 @@ export function TouchInteractionManager() {
         const deltaY = Math.abs(endY - touchStartCoordsRef.current.y)
 
         if (deltaX < 10 && deltaY < 10) {
-          // Consider it a tap; synthesize a click for reliability on iOS
-          e.preventDefault()
-          const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true, view: window })
-          closestInteractive.dispatchEvent(clickEvent)
-        }
-
-        if (now - lastTouchEndRef.current < 350) {
-          // Prevent zoom on double taps
-          e.preventDefault()
+          // Allow native click handling
         }
       }
 
-      lastTouchEndRef.current = now
       touchStartCoordsRef.current = null
     }
 
     document.addEventListener("touchstart", handleTouchStart, { passive: true })
     document.addEventListener("touchmove", handleTouchMove, { passive: false }) // passive:false for preventDefault
-    document.addEventListener("touchend", handleTouchEnd, { passive: false }) // passive:false for preventDefault
+    document.addEventListener("touchend", handleTouchEnd, { passive: true })
     const handleTouchCancel = () => {
       // Clean up active states on touchcancel
       document.querySelectorAll(".touch-active").forEach((el) => el.classList.remove("touch-active"))


### PR DESCRIPTION
## Summary
- drop synthetic click events and allow default browser tap behavior
- mark `touchend` listener as passive

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885f2b5d1608329ac7bd9d4ce201333