### PR TITLE
Fix syncData status indicators

### DIFF
--- a/hooks/use-supabase-data.ts
+++ b/hooks/use-supabase-data.ts
@@ -254,7 +254,9 @@ export function useSupabaseData() {
           // Load tables - SELECTIVE COLUMNS
           supabase
             .from(TABLE_NAMES.TABLES)
-            .select("id, name, is_active, start_time, remaining_time, initial_time, guest_count, server_id, group_id, has_notes, note_id, note_text, updated_by_admin, updated_by, updated_at"),
+            .select(
+              "id, name, is_active, start_time, remaining_time, initial_time, guest_count, server_id, group_id, has_notes, note_id, note_text, status_indicators, updated_by_admin, updated_by, updated_at",
+            ),
 
           // Load logs
           supabase
@@ -636,6 +638,7 @@ export function useSupabaseData() {
                         hasNotes: newTbl.has_notes,
                         noteId: newTbl.note_id || "",
                         noteText: newTbl.note_text || "",
+                        statusIndicators: newTbl.status_indicators || [],
                         updated_by_admin: newTbl.updated_by_admin || false,
                         updated_by: newTbl.updated_by || null,
                         updatedAt: newTbl.updated_at || new Date().toISOString(),

--- a/hooks/use-supabase-data.ts
+++ b/hooks/use-supabase-data.ts
@@ -1299,7 +1299,11 @@ export function useSupabaseData() {
         { data: settingsData, error: settingsError },
       ] = await Promise.all([
         // TABLES - SELECTIVE COLUMNS
-        supabase.from(TABLE_NAMES.TABLES).select("id, name, is_active, start_time, remaining_time, initial_time, guest_count, server_id, group_id, has_notes, note_id, note_text, updated_by_admin, updated_by, updated_at"),
+        supabase
+          .from(TABLE_NAMES.TABLES)
+          .select(
+            "id, name, is_active, start_time, remaining_time, initial_time, guest_count, server_id, group_id, has_notes, note_id, note_text, status_indicators, updated_by_admin, updated_by, updated_at",
+          ),
         supabase.from(TABLE_NAMES.LOGS).select("*").order("timestamp", { ascending: false }),
         supabase.from(TABLE_NAMES.SERVERS).select("*"),
         supabase.from(TABLE_NAMES.TEMPLATES).select("*"),
@@ -1326,6 +1330,7 @@ export function useSupabaseData() {
           hasNotes: table.has_notes,
           noteId: table.note_id || "",
           noteText: table.note_text || "",
+          statusIndicators: table.status_indicators || [],
           updated_by_admin: table.updated_by_admin || false,
           updated_by: table.updated_by || null,
           updatedAt: table.updated_at || new Date().toISOString(),


### PR DESCRIPTION
## Summary
- include `status_indicators` column when syncing tables
- preserve `statusIndicators` when mapping fetched tables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885fe5380988329aadecccbb2534f7a