### PR TITLE
Add weather widget to header

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { ConnectionStatus } from "@/components/system/connection-status"
 import { AnimatedLogo } from "@/components/ui/animated-logo"
+import { WeatherWidget } from "@/components/system/weather-widget"
 import type { Table, Server, LogEntry } from "@/components/system/billiards-timer-dashboard"
 
 interface HeaderProps {
@@ -106,11 +107,13 @@ export function Header({
             </div>
           </div>
 
-          {/* Digital clock */}
+          {/* Digital clock and weather */}
           <div className="flex items-center space-x-2">
             <div className="bg-black border border-cyan-500 rounded-md px-3 py-1 shadow-lg shadow-cyan-500/20">
               <span className="text-2xl font-mono text-cyan-400">{currentTimeString}</span>
             </div>
+            {/* Weather widget */}
+            <WeatherWidget />
           </div>
 
           {/* Right side controls */}

--- a/components/system/weather-widget.tsx
+++ b/components/system/weather-widget.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Sun, CloudRain, Cloud } from "lucide-react"
+import weatherService, { type CurrentWeather, type HourlyForecast } from "@/services/weather-service"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Spinner } from "@/components/ui/spinner"
+
+function getIconComponent(icon: string) {
+  if (icon.includes("rain")) return CloudRain
+  if (icon.includes("cloud")) return Cloud
+  return Sun
+}
+
+export function WeatherWidget() {
+  const [weather, setWeather] = useState<CurrentWeather | null>(null)
+  const [forecast, setForecast] = useState<HourlyForecast[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      const current = await weatherService.getCurrentWeather()
+      const hourly = await weatherService.getHourlyForecast()
+      setWeather(current)
+      setForecast(hourly)
+      setLoading(false)
+    }
+    fetchData()
+  }, [])
+
+  const Icon = weather ? getIconComponent(weather.icon) : Sun
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="bg-black border border-cyan-500 rounded-md px-2 py-1 shadow-lg shadow-cyan-500/20 flex items-center space-x-1 cursor-default">
+            {loading ? (
+              <Spinner className="h-4 w-4 text-cyan-400" />
+            ) : weather ? (
+              <>
+                <Icon className="h-4 w-4 text-yellow-400" />
+                <span className="text-sm text-cyan-400">{Math.round(weather.temp)}°C</span>
+              </>
+            ) : (
+              <span className="text-xs text-gray-400">N/A</span>
+            )}
+          </div>
+        </TooltipTrigger>
+        {forecast.length > 0 && (
+          <TooltipContent side="bottom">
+            <div className="text-xs space-y-1">
+              {forecast.map((f, idx) => (
+                <div key={idx} className="flex items-center justify-between">
+                  <span>{new Date(f.time * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
+                  <span>{Math.round(f.temp)}°C</span>
+                </div>
+              ))}
+            </div>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/services/weather-service.ts
+++ b/services/weather-service.ts
@@ -1,0 +1,62 @@
+"use client"
+
+const API_KEY = process.env.NEXT_PUBLIC_OPEN_WEATHER_API_KEY || ""
+const DEFAULT_LAT = parseFloat(process.env.NEXT_PUBLIC_DEFAULT_LAT || "40.7128")
+const DEFAULT_LON = parseFloat(process.env.NEXT_PUBLIC_DEFAULT_LON || "-74.0060")
+
+export interface CurrentWeather {
+  temp: number
+  description: string
+  icon: string
+}
+
+export interface HourlyForecast {
+  time: number
+  temp: number
+  icon: string
+}
+
+class WeatherService {
+  async getCurrentWeather(lat: number = DEFAULT_LAT, lon: number = DEFAULT_LON): Promise<CurrentWeather | null> {
+    if (!API_KEY) {
+      console.warn("OpenWeather API key not configured")
+      return null
+    }
+    try {
+      const url = `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=metric&appid=${API_KEY}`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error("Failed to fetch weather")
+      const data = await res.json()
+      return {
+        temp: data.main.temp,
+        description: data.weather[0].description,
+        icon: data.weather[0].icon,
+      }
+    } catch (err) {
+      console.error("WeatherService:getCurrentWeather", err)
+      return null
+    }
+  }
+
+  async getHourlyForecast(lat: number = DEFAULT_LAT, lon: number = DEFAULT_LON): Promise<HourlyForecast[]> {
+    if (!API_KEY) return []
+    try {
+      const url = `https://api.openweathermap.org/data/2.5/forecast?lat=${lat}&lon=${lon}&units=metric&cnt=6&appid=${API_KEY}`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error("Failed to fetch forecast")
+      const data = await res.json()
+      const list = (data.list || []) as any[]
+      return list.slice(0, 5).map((item) => ({
+        time: item.dt,
+        temp: item.main.temp,
+        icon: item.weather[0].icon,
+      }))
+    } catch (err) {
+      console.error("WeatherService:getHourlyForecast", err)
+      return []
+    }
+  }
+}
+
+const weatherService = new WeatherService()
+export default weatherService


### PR DESCRIPTION
## Summary
- create weather service using OpenWeather API
- add WeatherWidget component
- display WeatherWidget next to digital clock

## Testing
- `pnpm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68860bc094108329915c78b267801fd6